### PR TITLE
fix: npmjsにプロべナンスを追加する

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,3 +67,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Hiratake/aws-mfa.git"
+  },
   "type": "module",
   "exports": {
     "types": "./dist/index.d.mts",


### PR DESCRIPTION
`npmjs.com` のバージョン一覧に認証バッジを追加する。

- https://github.com/semantic-release/npm?tab=readme-ov-file#npm-provenance
- https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools